### PR TITLE
Unlinkify email address to satisfy linkchecker

### DIFF
--- a/src/doc/rustc/src/platform-support/x86_64-unknown-none.md
+++ b/src/doc/rustc/src/platform-support/x86_64-unknown-none.md
@@ -6,7 +6,7 @@ Freestanding/bare-metal x86-64 binaries in ELF format: firmware, kernels, etc.
 
 ## Target maintainers
 
-- Harald Hoyer <harald@profian.com>, https://github.com/haraldh
+- Harald Hoyer `harald@profian.com`, https://github.com/haraldh
 - Mike Leany, https://github.com/mikeleany
 
 ## Requirements


### PR DESCRIPTION
The linkchecker doesn't seem happy with links to email addresses.